### PR TITLE
fix: persist configure sync screen data on navigation

### DIFF
--- a/src/views/Activate/Syncs/EditSync/EditSync.tsx
+++ b/src/views/Activate/Syncs/EditSync/EditSync.tsx
@@ -213,6 +213,7 @@ const EditSync = (): JSX.Element | null => {
               handleOnConfigChange={handleOnConfigChange}
               data={configuration}
               isEdit
+              configuration={configuration}
             />
             <ScheduleForm formik={formik} />
           </React.Fragment>

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/ConfigureSyncs.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/ConfigureSyncs.tsx
@@ -1,28 +1,35 @@
-import ContentContainer from "@/components/ContentContainer";
-import { SteppedFormContext } from "@/components/SteppedForm/SteppedForm";
-import { ModelEntity } from "@/views/Models/types";
-import { Box } from "@chakra-ui/react";
-import { FormEvent, useContext, useState } from "react";
-import SelectStreams from "./SelectStreams";
-import { Stream } from "@/views/Activate/Syncs/types";
-import MapFields from "./MapFields";
-import { ConnectorItem } from "@/views/Connectors/types";
-import SourceFormFooter from "@/views/Connectors/Sources/SourcesForm/SourceFormFooter";
+import ContentContainer from '@/components/ContentContainer';
+import { SteppedFormContext } from '@/components/SteppedForm/SteppedForm';
+import { ModelEntity } from '@/views/Models/types';
+import { Box } from '@chakra-ui/react';
+import { FormEvent, useContext, Dispatch, SetStateAction } from 'react';
+import SelectStreams from './SelectStreams';
+import { Stream } from '@/views/Activate/Syncs/types';
+import MapFields from './MapFields';
+import { ConnectorItem } from '@/views/Connectors/types';
+import SourceFormFooter from '@/views/Connectors/Sources/SourcesForm/SourceFormFooter';
 
-const ConfigureSyncs = (): JSX.Element | null => {
-  const [selectedStream, setSelectedStream] = useState<Stream | null>(null);
-  const [configuration, setConfiguration] = useState<Record<
-    string,
-    string
-  > | null>(null);
+type ConfigureSyncsProps = {
+  selectedStream: Stream | null;
+  configuration: Record<string, string> | null;
+  setSelectedStream: Dispatch<SetStateAction<Stream | null>>;
+  setConfiguration: Dispatch<SetStateAction<Record<string, string> | null>>;
+};
+
+const ConfigureSyncs = ({
+  selectedStream,
+  configuration,
+  setSelectedStream,
+  setConfiguration,
+}: ConfigureSyncsProps): JSX.Element | null => {
   const { state, stepInfo, handleMoveForward } = useContext(SteppedFormContext);
   const { forms } = state;
 
-  const modelInfo = forms.find((form) => form.stepKey === "selectModel");
+  const modelInfo = forms.find((form) => form.stepKey === 'selectModel');
   const selectedModel = modelInfo?.data?.selectModel as ModelEntity;
 
   const destinationInfo = forms.find(
-    (form) => form.stepKey === "selectDestination"
+    (form) => form.stepKey === 'selectDestination'
   );
   const selectedDestination = destinationInfo?.data
     ?.selectDestination as ConnectorItem;
@@ -49,23 +56,25 @@ const ConfigureSyncs = (): JSX.Element | null => {
   };
 
   return (
-    <Box width="100%" display="flex" justifyContent="center">
+    <Box width='100%' display='flex' justifyContent='center'>
       <ContentContainer>
         <form onSubmit={handleOnSubmit}>
           <SelectStreams
             model={selectedModel}
             onChange={handleOnStreamChange}
             destination={selectedDestination}
+            selectedStream={selectedStream}
           />
           <MapFields
             model={selectedModel}
             destination={selectedDestination}
             stream={selectedStream}
             handleOnConfigChange={handleOnConfigChange}
+            configuration={configuration}
           />
           <SourceFormFooter
-            ctaName="Continue"
-            ctaType="submit"
+            ctaName='Continue'
+            ctaType='submit'
             isCtaDisabled={!selectedStream}
             isBackRequired
           />

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/FieldMap.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/FieldMap.tsx
@@ -40,7 +40,7 @@ const FieldMap = ({
           borderWidth='1px'
           borderStyle='solid'
           borderColor='gray.400'
-          color='gray.600'
+          color='black.500'
         >
           {options.map((option) => (
             <option

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/FieldMap.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/FieldMap.tsx
@@ -8,9 +8,9 @@ type FieldMapProps = {
   entityName: string;
   options: string[];
   disabledOptions?: string[];
-  value: string;
   isDisabled: boolean;
   onChange: (id: number, type: 'model' | 'destination', value: string) => void;
+  selectedConfigOptions?: string[];
 };
 
 const FieldMap = ({
@@ -20,9 +20,9 @@ const FieldMap = ({
   entityName,
   options,
   disabledOptions = [],
-  value,
   onChange,
   isDisabled,
+  selectedConfigOptions,
 }: FieldMapProps): JSX.Element => {
   return (
     <Box width='100%'>
@@ -31,7 +31,7 @@ const FieldMap = ({
       </Box>
       <Box>
         <Select
-          value={value}
+          value={selectedConfigOptions?.[id]}
           placeholder={`Select a field from ${entityName}`}
           backgroundColor='gray.100'
           isDisabled={isDisabled}

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -8,9 +8,9 @@ import FieldMap from './FieldMap';
 import {
   convertFieldMapToConfig,
   getPathFromObject,
-} from "@/views/Activate/Syncs/utils";
-import { useEffect, useMemo, useState } from "react";
-import { ArrowRightIcon } from "@heroicons/react/24/outline";
+} from '@/views/Activate/Syncs/utils';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
 
 type MapFieldsProps = {
   model: ModelEntity;
@@ -19,6 +19,7 @@ type MapFieldsProps = {
   data?: Record<string, string> | null;
   isEdit?: boolean;
   handleOnConfigChange: (args: Record<string, string>) => void;
+  configuration?: Record<string, string> | null;
 };
 
 const FieldStruct: FieldMapType = {
@@ -33,6 +34,7 @@ const MapFields = ({
   data,
   isEdit,
   handleOnConfigChange,
+  configuration,
 }: MapFieldsProps): JSX.Element | null => {
   const [fields, setFields] = useState<FieldMapType[]>([FieldStruct]);
   const { data: previewModelData } = useQuery({
@@ -40,7 +42,7 @@ const MapFields = ({
     queryFn: () =>
       getModelPreviewById(model?.query, String(model?.connector?.id)),
     enabled: !!model?.connector?.id,
-    refetchOnMount: true,
+    refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
 
@@ -91,12 +93,17 @@ const MapFields = ({
 
   const mappedColumns = fields.map((item) => item.model);
 
+  const souceConfigList = configuration ? Object.keys(configuration) : [];
+  const destinationConfigList = configuration
+    ? Object.values(configuration)
+    : [];
+
   return (
     <Box
-      backgroundColor="gray.300"
-      padding="20px"
-      borderRadius="8px"
-      marginBottom={isEdit ? "20px" : "100px"}
+      backgroundColor='gray.300'
+      padding='20px'
+      borderRadius='8px'
+      marginBottom={isEdit ? '20px' : '100px'}
     >
       <Text fontWeight={600} size='md'>
         Map fields to {destination?.attributes?.connector_name}
@@ -124,9 +131,9 @@ const MapFields = ({
             icon={model.connector.icon}
             options={modelColumns}
             disabledOptions={mappedColumns}
-            value={fields[index].model}
             onChange={handleOnChange}
             isDisabled={!stream}
+            selectedConfigOptions={souceConfigList}
           />
           <Box
             width='80px'
@@ -143,9 +150,9 @@ const MapFields = ({
             entityName={destination.attributes.connector_name}
             icon={destination.attributes.icon}
             options={destinationColumns}
-            value={fields[index].destination}
             onChange={handleOnChange}
             isDisabled={!stream}
+            selectedConfigOptions={destinationConfigList}
           />
           <Box py='20px' position='relative' top='12px' color='gray.600'>
             <CloseButton

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/SelectStreams.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/SelectStreams.tsx
@@ -1,10 +1,10 @@
-import { Box, Text, Select } from "@chakra-ui/react";
-import { DiscoverResponse, Stream } from "@/views/Activate/Syncs/types";
-import { ModelEntity } from "@/views/Models/types";
-import { useQuery } from "@tanstack/react-query";
-import { getCatalog } from "@/services/syncs";
-import { ConnectorItem } from "@/views/Connectors/types";
-import { useEffect } from "react";
+import { Box, Text, Select } from '@chakra-ui/react';
+import { DiscoverResponse, Stream } from '@/views/Activate/Syncs/types';
+import { ModelEntity } from '@/views/Models/types';
+import { useQuery } from '@tanstack/react-query';
+import { getCatalog } from '@/services/syncs';
+import { ConnectorItem } from '@/views/Connectors/types';
+import { useEffect } from 'react';
 
 type SelectStreamsProps = {
   model: ModelEntity;
@@ -13,6 +13,7 @@ type SelectStreamsProps = {
   placeholder?: string;
   onChange?: (stream: Stream) => void;
   onStreamsLoad?: (catalog: DiscoverResponse) => void;
+  selectedStream?: Stream | null;
 };
 
 const SelectStreams = ({
@@ -22,9 +23,10 @@ const SelectStreams = ({
   placeholder,
   onChange,
   onStreamsLoad,
+  selectedStream,
 }: SelectStreamsProps): JSX.Element | null => {
   const { data: catalogData } = useQuery({
-    queryKey: ["syncs", "catalog", destination.id],
+    queryKey: ['syncs', 'catalog', destination.id],
     queryFn: () => getCatalog(destination.id),
     enabled: !!destination.id,
     refetchOnMount: false,
@@ -47,6 +49,11 @@ const SelectStreams = ({
     const selectedStream = streams[parseInt(streamNumber)];
     onChange?.(selectedStream);
   };
+
+  const selectedStreamIndex = streams.findIndex(
+    (stream) => stream.name === selectedStream?.name
+  );
+
   return (
     <Box
       backgroundColor='gray.300'
@@ -57,18 +64,19 @@ const SelectStreams = ({
       <Text fontWeight='600' mb={6} color='black.500' size='md'>
         Configure sync to {model?.connector?.connector_name}
       </Text>
-      <Text fontWeight="600">Stream Name</Text>
-      <Text fontSize="sm" marginBottom="10px">
+      <Text fontWeight='600'>Stream Name</Text>
+      <Text fontSize='sm' marginBottom='10px'>
         {isEdit
-          ? "You cannot change the API once the mapping is done."
-          : "Select the API from the destination that you wish to map."}
+          ? 'You cannot change the API once the mapping is done.'
+          : 'Select the API from the destination that you wish to map.'}
       </Text>
       <Select
-        placeholder={isEdit ? placeholder : "Select option"}
-        backgroundColor="#fff"
-        maxWidth="500px"
+        placeholder={isEdit ? placeholder : 'Select option'}
+        backgroundColor='#fff'
+        maxWidth='500px'
         onChange={(e) => handleOnStreamChange(e.target.value)}
         isDisabled={isEdit}
+        value={selectedStreamIndex}
       >
         {streams.map((stream, index) => (
           <option key={stream.name} value={index}>

--- a/src/views/Activate/Syncs/SyncForm/SelectDestination/SelectDestination.tsx
+++ b/src/views/Activate/Syncs/SyncForm/SelectDestination/SelectDestination.tsx
@@ -1,24 +1,35 @@
-import ContentContainer from "@/components/ContentContainer";
-import Loader from "@/components/Loader";
-import { SteppedFormContext } from "@/components/SteppedForm/SteppedForm";
-import { getUserConnectors } from "@/services/connectors";
-import DestinationsTable from "@/views/Connectors/Destinations/DestinationsList/DestinationsTable";
-import NoConnectors from "@/views/Connectors/NoConnectors";
-import { DESTINATIONS_LIST_QUERY_KEY } from "@/views/Connectors/constant";
-import { Box } from "@chakra-ui/react";
-import { useQuery } from "@tanstack/react-query";
-import { useContext } from "react";
+import ContentContainer from '@/components/ContentContainer';
+import Loader from '@/components/Loader';
+import { SteppedFormContext } from '@/components/SteppedForm/SteppedForm';
+import { getUserConnectors } from '@/services/connectors';
+import DestinationsTable from '@/views/Connectors/Destinations/DestinationsList/DestinationsTable';
+import NoConnectors from '@/views/Connectors/NoConnectors';
+import { DESTINATIONS_LIST_QUERY_KEY } from '@/views/Connectors/constant';
+import { Box } from '@chakra-ui/react';
+import { useQuery } from '@tanstack/react-query';
+import { useContext, Dispatch, SetStateAction } from 'react';
+import { Stream } from '@/views/Activate/Syncs/types';
 
-const SelectDestination = (): JSX.Element => {
+const SelectDestination = ({
+  setSelectedStream,
+  setConfiguration,
+}: {
+  setSelectedStream: Dispatch<SetStateAction<Stream | null>>;
+  setConfiguration: Dispatch<SetStateAction<Record<string, string> | null>>;
+}): JSX.Element => {
   const { stepInfo, handleMoveForward } = useContext(SteppedFormContext);
 
-  const handleOnRowClick = (data: Record<"connector", unknown>) => {
+  const handleOnRowClick = (data: Record<'connector', unknown>) => {
+    // to reset the state of config sync screen
+    setSelectedStream(null);
+    setConfiguration(null);
+
     handleMoveForward(stepInfo?.formKey as string, data?.connector);
   };
 
   const { data, isLoading } = useQuery({
     queryKey: DESTINATIONS_LIST_QUERY_KEY,
-    queryFn: () => getUserConnectors("destination"),
+    queryFn: () => getUserConnectors('destination'),
     refetchOnMount: false,
     refetchOnWindowFocus: false,
   });
@@ -26,10 +37,10 @@ const SelectDestination = (): JSX.Element => {
   if (isLoading && !data) return <Loader />;
 
   if (data?.data.length === 0)
-    return <NoConnectors connectorType="destination" />;
+    return <NoConnectors connectorType='destination' />;
 
   return (
-    <Box width="100%" display="flex" justifyContent="center">
+    <Box width='100%' display='flex' justifyContent='center'>
       <ContentContainer>
         {isLoading || !data ? (
           <Loader />

--- a/src/views/Activate/Syncs/SyncForm/SyncForm.tsx
+++ b/src/views/Activate/Syncs/SyncForm/SyncForm.tsx
@@ -1,51 +1,71 @@
-import SteppedForm from "@/components/SteppedForm";
+import { useState } from 'react';
+import SteppedForm from '@/components/SteppedForm';
+import { Stream } from '@/views/Activate/Syncs/types';
+
 import {
   Box,
   Drawer,
   DrawerBody,
   DrawerContent,
   DrawerOverlay,
-} from "@chakra-ui/react";
-import { useNavigate } from "react-router-dom";
-import SelectModel from "./SelectModel";
-import SelectDestination from "./SelectDestination";
-import ConfigureSyncs from "./ConfigureSyncs";
-import FinaliseSync from "./FinaliseSync";
+} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import SelectModel from './SelectModel';
+import SelectDestination from './SelectDestination';
+import ConfigureSyncs from './ConfigureSyncs';
+import FinaliseSync from './FinaliseSync';
 
 const SyncForm = (): JSX.Element => {
+  const [selectedStream, setSelectedStream] = useState<Stream | null>(null);
+  const [configuration, setConfiguration] = useState<Record<
+    string,
+    string
+  > | null>(null);
   const navigate = useNavigate();
   const steps = [
     {
-      formKey: "selectModel",
-      name: "Select a model",
+      formKey: 'selectModel',
+      name: 'Select a model',
       component: <SelectModel />,
       isRequireContinueCta: false,
     },
     {
-      formKey: "selectDestination",
-      name: "Select a destination",
-      component: <SelectDestination />,
+      formKey: 'selectDestination',
+      name: 'Select a destination',
+      component: (
+        <SelectDestination
+          setSelectedStream={setSelectedStream}
+          setConfiguration={setConfiguration}
+        />
+      ),
       isRequireContinueCta: false,
     },
     {
-      formKey: "configureSyncs",
-      name: "Configure sync",
-      component: <ConfigureSyncs />,
+      formKey: 'configureSyncs',
+      name: 'Configure sync',
+      component: (
+        <ConfigureSyncs
+          selectedStream={selectedStream}
+          configuration={configuration}
+          setSelectedStream={setSelectedStream}
+          setConfiguration={setConfiguration}
+        />
+      ),
       isRequireContinueCta: false,
     },
     {
-      formKey: "finaliseSync",
-      name: "Finalize sync",
+      formKey: 'finaliseSync',
+      name: 'Finalize sync',
       component: <FinaliseSync />,
       isRequireContinueCta: false,
     },
   ];
 
   return (
-    <Drawer isOpen onClose={() => navigate(-1)} placement="right" size="100%">
+    <Drawer isOpen onClose={() => navigate(-1)} placement='right' size='100%'>
       <DrawerOverlay />
-      <DrawerContent padding="0px">
-        <DrawerBody padding="0px">
+      <DrawerContent padding='0px'>
+        <DrawerBody padding='0px'>
           <Box>
             <SteppedForm steps={steps} />
           </Box>

--- a/src/views/Models/EditModel/EditModel.tsx
+++ b/src/views/Models/EditModel/EditModel.tsx
@@ -23,8 +23,6 @@ const EditModel = (): JSX.Element => {
     refetchOnWindowFocus: true,
   });
 
-  console.log(data);
-
   const prefillValues: PrefillValue = {
     connector_id: data?.data?.attributes.connector.id || "",
     connector_icon: (

--- a/src/views/Models/ModelsForm/DefineModel/DefineSQL/DefineSQL.tsx
+++ b/src/views/Models/ModelsForm/DefineModel/DefineSQL/DefineSQL.tsx
@@ -48,8 +48,6 @@ const DefineSQL = ({
   if (!hasPrefilledValues) {
     const extracted = extractData(state.forms);
     const connector_data = extracted.find((data) => data?.id);
-    console.log(connector_data?.icon);
-    console.log(connector_data?.name);
     connector_id = connector_data?.id || "";
     connector_icon = connector_data?.icon || <></>;
   } else {

--- a/src/views/Models/ModelsForm/SelectModelSourceForm/SelectModelSourceForm.tsx
+++ b/src/views/Models/ModelsForm/SelectModelSourceForm/SelectModelSourceForm.tsx
@@ -108,7 +108,6 @@ const SelectModelSourceForm = (): JSX.Element | null => {
           <Loader />
         ) : (
           <Table data={tableData} onRowClick={(row) => handleOnRowClick(row)} />
-          // <Table data={tableData} onRowClick={(row) => console.log(row)} />
         )}
       </ContentContainer>
     </Box>


### PR DESCRIPTION
When we create a Sync, on step 3 after adding the mapping and moving to step 4, when we hit the back button, the previous state of mapping and stream selection is lost - this PR fixes this bug


https://github.com/Multiwoven/multiwoven-ui/assets/29303618/d784f260-ee18-4b2b-8aa0-de1e3e1b5fb2

