### PR TITLE
fix: pre-render components during edit sync

### DIFF
--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -61,9 +61,7 @@ const MapFields = ({
     }
   }, [data]);
 
-  if (!previewModelData || !Array.isArray(previewModelData)) return null;
-
-  const firstRow = previewModelData[0];
+  const firstRow = Array.isArray(previewModelData) && previewModelData[0];
 
   const modelColumns = Object.keys(firstRow ?? {});
 

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/SelectStreams.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/SelectStreams.tsx
@@ -39,18 +39,18 @@ const SelectStreams = ({
     }
   }, [catalogData]);
 
-  if (!catalogData) return null;
-
   const streams = catalogData?.data?.attributes?.catalog?.streams;
 
   const handleOnStreamChange = (streamNumber: string) => {
     if (!streamNumber) return;
 
-    const selectedStream = streams[parseInt(streamNumber)];
-    onChange?.(selectedStream);
+    if (streams) {
+      const selectedStream = streams[parseInt(streamNumber)];
+      onChange?.(selectedStream);
+    }
   };
 
-  const selectedStreamIndex = streams.findIndex(
+  const selectedStreamIndex = streams?.findIndex(
     (stream) => stream.name === selectedStream?.name
   );
 
@@ -78,7 +78,7 @@ const SelectStreams = ({
         isDisabled={isEdit}
         value={selectedStreamIndex}
       >
-        {streams.map((stream, index) => (
+        {streams?.map((stream, index) => (
           <option key={stream.name} value={index}>
             {stream.name}
           </option>


### PR DESCRIPTION
Currently, when we edit a sync, the components only load when the data is fetched because of which the components show up on screen in chunks causing a bad UX.
Fixed this so that the component will render and once the data is fetched, it will be filled accordingly.


https://github.com/Multiwoven/multiwoven-ui/assets/29303618/dbc50fac-b29e-45ce-a56d-83113c71e242

