### PR TITLE
Added API_HOST ENV check

### DIFF
--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,7 +1,9 @@
 import axios from "axios";
 import Cookies from "js-cookie";
 
-export const domain = "https://api.multiwoven.com/api/v1";
+export const domain = import.meta.env.VITE_API_HOST || "http://localhost:3000";
+console.log(domain);
+
 export const axiosInstance = axios.create({
   baseURL: domain,
 });

--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -2,8 +2,6 @@ import axios from "axios";
 import Cookies from "js-cookie";
 
 export const domain = import.meta.env.VITE_API_HOST || "http://localhost:3000";
-console.log(domain);
-
 export const axiosInstance = axios.create({
   baseURL: domain,
 });


### PR DESCRIPTION
# Added checking for API_HOST in axios.ts

## When API_HOST is not there in .env
![image](https://github.com/Multiwoven/multiwoven-ui/assets/54372016/a6c480f3-c3f0-47c0-94f7-b9523daf2222)


## When API_HOST is there in .env
![image](https://github.com/Multiwoven/multiwoven-ui/assets/54372016/8b6e25ee-24be-40d6-9d5b-b5fcf2cc35fc)

Using wrong password as an example to show that the API being called is the one set in the Environment Variable