### PR TITLE
fix: refetch data on component mount

### DIFF
--- a/src/views/Activate/Syncs/EditSync/EditSync.tsx
+++ b/src/views/Activate/Syncs/EditSync/EditSync.tsx
@@ -20,8 +20,8 @@ import {
 } from '@/views/Activate/Syncs/types';
 import ScheduleForm from './ScheduleForm';
 import { FormikProps, useFormik } from 'formik';
-import FormFooter from '@/components/FormFooter';
 import SyncActions from './SyncActions';
+import SourceFormFooter from '@/views/Connectors/Sources/SourcesForm/SourceFormFooter';
 
 const EditSync = (): JSX.Element | null => {
   const [selectedStream, setSelectedStream] = useState<Stream | null>(null);
@@ -38,7 +38,7 @@ const EditSync = (): JSX.Element | null => {
   } = useQuery({
     queryKey: ['sync', syncId],
     queryFn: () => getSyncById(syncId as string),
-    refetchOnMount: false,
+    refetchOnMount: true,
     refetchOnWindowFocus: false,
     enabled: !!syncId,
   });
@@ -209,11 +209,14 @@ const EditSync = (): JSX.Element | null => {
             <ScheduleForm formik={formik} isEdit />
           </React.Fragment>
         ) : null}
-        <FormFooter
+        <SourceFormFooter
           ctaName='Save Changes'
           ctaType='submit'
           isCtaLoading={isEditLoading}
           isAlignToContentContainer
+          isDocumentsSectionRequired
+          isContinueCtaRequired
+          isBackRequired
         />
       </ContentContainer>
     </form>

--- a/src/views/Activate/Syncs/EditSync/ScheduleForm.tsx
+++ b/src/views/Activate/Syncs/EditSync/ScheduleForm.tsx
@@ -80,6 +80,7 @@ const ScheduleForm = ({ formik, isEdit }: ScheduleFormProps) => {
                 borderWidth='1px'
                 borderStyle='solid'
                 borderColor='gray.400'
+                height='40px'
               >
                 <Box>
                   <Text>Every</Text>
@@ -95,6 +96,7 @@ const ScheduleForm = ({ formik, isEdit }: ScheduleFormProps) => {
                     value={formik.values.sync_interval}
                     onChange={formik.handleChange}
                     isRequired
+                    height='35px'
                   />
                 </Box>
                 <Divider orientation='vertical' height='24px' color='gray.400' />

--- a/src/views/Activate/Syncs/SyncForm/FinaliseSync/FinaliseSync.tsx
+++ b/src/views/Activate/Syncs/SyncForm/FinaliseSync/FinaliseSync.tsx
@@ -186,6 +186,7 @@ const FinaliseSync = (): JSX.Element => {
                           onChange={formik.handleChange}
                           isRequired
                           color='gray.600'
+                          height='35px'
                         />
                       </Box>
                       <Divider orientation='vertical' height='24px' color='gray.400' />

--- a/src/views/Models/ModelsForm/DefineModel/DefineSQL/DefineSQL.tsx
+++ b/src/views/Models/ModelsForm/DefineModel/DefineSQL/DefineSQL.tsx
@@ -16,7 +16,6 @@ import { DefineSQLProps } from './types';
 import { UpdateModelPayload } from '@/views/Models/ViewModel/types';
 import ContentContainer from '@/components/ContentContainer';
 import SourceFormFooter from '@/views/Connectors/Sources/SourcesForm/SourceFormFooter';
-import FormFooter from '@/components/FormFooter';
 
 const DefineSQL = ({
   hasPrefilledValues = false,
@@ -242,13 +241,15 @@ const DefineSQL = ({
         </Box>
       </ContentContainer>
       {isUpdateButtonVisible ? (
-        <FormFooter
+        <SourceFormFooter
           ctaName='Save Changes'
           ctaType='button'
           isCtaDisabled={!moveForward}
           isAlignToContentContainer
           isBackRequired
           onCtaClick={handleModelUpdate}
+          isContinueCtaRequired
+          isDocumentsSectionRequired
         />
       ) : (
         <SourceFormFooter


### PR DESCRIPTION
## Description
The edit sync data were being cached and it was not changing when we were trying to edit a new sync. Fixed the issue to re-fetch data on the component mount.


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore
  
## How Has This Been Tested?
Edited a sync, came back to the list screen, and tried editing a different sync.
The details were not cached.

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meet the guidelines?
- [ ] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [x] Have you made sure the code you have written follows the best practices to the best of your knowledge?
