### PR TITLE
show/hide fix in hiddenInput

### DIFF
--- a/src/components/HiddenInput/HiddenInput.tsx
+++ b/src/components/HiddenInput/HiddenInput.tsx
@@ -28,10 +28,10 @@ const HiddenInput = (props: InputProps): JSX.Element => {
       <Input
         id="password"
         name="password"
-        type={isOpen ? "text" : "password"}
         autoComplete="current-password"
         required
         {...props}
+        type={isOpen ? "text" : "password"}
       />
     </InputGroup>
   );


### PR DESCRIPTION
## Description

Fixes a bug on the sign-in and sign-up pages where the password remains obscured even after clicking the eye icon to reveal it.

## Related Issue
#88 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore
  
## How Has This Been Tested?


## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [x] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meet the guidelines?
- [ ] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [x] Have you made sure the code you have written follows the best practices to the best of your knowledge?
