### PR TITLE
Revert "Fix Sidebar Overlap of menu items and footer "

### DIFF
--- a/src/views/Sidebar/Sidebar.tsx
+++ b/src/views/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Stack, Text, Divider, VStack } from '@chakra-ui/react';
+import { Box, Flex, Stack, Text, Divider } from '@chakra-ui/react';
 import { NavLink } from 'react-router-dom';
 import IconImage from '../../assets/images/multiwoven-logo.png';
 import {
@@ -89,7 +89,7 @@ const renderMenuSection = (section: MenuSection, index: number) => (
 );
 
 const SideBarFooter = () => (
-  <Stack spacing='0' margin='24px 16px'>
+  <Stack position='absolute' bottom='0' left='0px' right='0px' margin='24px 16px'>
     <Box />
     <Stack spacing='0'>
       <NavButton label='Settings' icon={FiSettings} disabled={true} />
@@ -111,17 +111,9 @@ const Sidebar = (): JSX.Element => {
       borderRightWidth='1px'
       borderRightStyle='solid'
       borderRightColor='gray.400'
-      direction='column'
     >
-      <Flex
-        flex='1'
-        bg='bg.surface'
-        maxW={{ base: 'full', sm: 'xs' }}
-        paddingX={4}
-        paddingY={6}
-        direction='column'
-      >
-        <VStack justify='space-between' spacing='1' width='full' height='full'>
+      <Flex flex='1' bg='bg.surface' maxW={{ base: 'full', sm: 'xs' }} paddingX={4} paddingY={6}>
+        <Stack justify='space-between' spacing='1' width='full'>
           <Stack spacing='6' shouldWrapChildren>
             <Flex justifyContent='center'>
               <img width={160} src={IconImage} alt='IconImage' />
@@ -130,9 +122,9 @@ const Sidebar = (): JSX.Element => {
               <Divider orientation='horizontal' />
             </Box>
             {menus.map(renderMenuSection)}
+            <SideBarFooter />
           </Stack>
-          <SideBarFooter />
-        </VStack>
+        </Stack>
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
Reverts Multiwoven/multiwoven-ui#98

This change has misaligned the existing designs of the sidebar

<img width="1473" alt="Screenshot 2024-03-11 at 2 16 15 PM" src="https://github.com/Multiwoven/multiwoven-ui/assets/29303618/d72d19a9-1551-4a97-a461-5fcb8b556486">

It is occupying more space and is deviating from the original designs.

> Original design

<img width="1512" alt="Screenshot 2024-03-11 at 2 16 54 PM" src="https://github.com/Multiwoven/multiwoven-ui/assets/29303618/ec1a1ac8-8e1b-4863-972a-d0892ea165d5">
