### PR TITLE
feat: pre-populate required destination mapping fields

### DIFF
--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -47,8 +47,6 @@ const MapFields = ({
     [stream],
   );
 
-  //console.log(destinationColumns, requiredDestinationColumns);
-
   useEffect(() => {
     if (data) {
       const fields = Object.keys(data).map((modelKey) => ({
@@ -92,11 +90,11 @@ const MapFields = ({
     if (!isEdit) {
       const updatedFields = destinationColumns
         .filter((property) => requiredDestinationColumns.includes(property))
-        .map((field, index) => ({ model: `model_${index}`, destination: field }));
+        .map((field, index) => ({ model: `model_${index}`, destination: field, isRequired: true }));
 
       // if only one destination field, we by default select it
       if (destinationColumns.length === 1) {
-        updatedFields.push({ model: '', destination: destinationColumns[0] });
+        updatedFields.push({ model: '', destination: destinationColumns[0], isRequired: true });
       }
 
       if (updatedFields.length > 0) {
@@ -134,7 +132,7 @@ const MapFields = ({
       <Text size='xs' mb={6} letterSpacing='-0.12px' fontWeight={400} color='black.200'>
         Select the API from the Destination that you wish to map.
       </Text>
-      {fields.map((_, index) => (
+      {fields.map(({ isRequired = false }, index) => (
         <Box key={`field-map-${index}`} display='flex' alignItems='flex-end' marginBottom='30px'>
           <FieldMap
             id={index}
@@ -157,17 +155,19 @@ const MapFields = ({
             icon={destination.attributes.icon}
             options={destinationColumns}
             onChange={handleOnChange}
-            isDisabled={!stream}
+            isDisabled={!stream || isRequired}
             selectedConfigOptions={destinationConfigList}
           />
-          <Box py='20px' position='relative' top='12px' color='gray.600'>
-            <CloseButton
-              size='sm'
-              marginLeft='10px'
-              _hover={{ backgroundColor: 'none' }}
-              onClick={() => handleRemoveMap(index)}
-            />
-          </Box>
+          {!isRequired && (
+            <Box py='20px' position='relative' top='12px' color='gray.600'>
+              <CloseButton
+                size='sm'
+                marginLeft='10px'
+                _hover={{ backgroundColor: 'none' }}
+                onClick={() => handleRemoveMap(index)}
+              />
+            </Box>
+          )}
         </Box>
       ))}
       <Box>

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -88,17 +88,21 @@ const MapFields = ({
   const souceConfigList = configuration ? Object.keys(configuration) : [];
   const destinationConfigList = configuration ? Object.values(configuration) : [];
 
-  //console.log(fields);
-
   useEffect(() => {
     if (!isEdit) {
       const updatedFields = destinationColumns
         .filter((property) => requiredDestinationColumns.includes(property))
-        .map((field) => ({ model: '', destination: field }));
+        .map((field, index) => ({ model: `model_${index}`, destination: field }));
+
+      // if only one destination field, we by default select it
+      if (destinationColumns.length === 1) {
+        updatedFields.push({ model: '', destination: destinationColumns[0] });
+      }
+
       if (updatedFields.length > 0) {
         setFields(updatedFields);
+        handleOnConfigChange(convertFieldMapToConfig(updatedFields));
       }
-      console.log(updatedFields);
     }
   }, [requiredDestinationColumns]);
 

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -47,6 +47,8 @@ const MapFields = ({
     [stream],
   );
 
+  //console.log(destinationColumns, requiredDestinationColumns);
+
   useEffect(() => {
     if (data) {
       const fields = Object.keys(data).map((modelKey) => ({
@@ -85,6 +87,20 @@ const MapFields = ({
 
   const souceConfigList = configuration ? Object.keys(configuration) : [];
   const destinationConfigList = configuration ? Object.values(configuration) : [];
+
+  //console.log(fields);
+
+  useEffect(() => {
+    if (!isEdit) {
+      const updatedFields = destinationColumns
+        .filter((property) => requiredDestinationColumns.includes(property))
+        .map((field) => ({ model: '', destination: field }));
+      if (updatedFields.length > 0) {
+        setFields(updatedFields);
+      }
+      console.log(updatedFields);
+    }
+  }, [requiredDestinationColumns]);
 
   useEffect(() => {
     let FieldStruct: FieldMapType[] = [];

--- a/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
+++ b/src/views/Activate/Syncs/SyncForm/ConfigureSyncs/MapFields.tsx
@@ -5,7 +5,11 @@ import { getModelPreviewById } from '@/services/models';
 import { useQuery } from '@tanstack/react-query';
 import { FieldMap as FieldMapType, Stream } from '@/views/Activate/Syncs/types';
 import FieldMap from './FieldMap';
-import { convertFieldMapToConfig, getPathFromObject } from '@/views/Activate/Syncs/utils';
+import {
+  convertFieldMapToConfig,
+  getPathFromObject,
+  getRequiredProperties,
+} from '@/views/Activate/Syncs/utils';
 import { useEffect, useMemo, useState } from 'react';
 import { ArrowRightIcon } from '@heroicons/react/24/outline';
 
@@ -38,6 +42,10 @@ const MapFields = ({
   });
 
   const destinationColumns = useMemo(() => getPathFromObject(stream?.json_schema), [stream]);
+  const requiredDestinationColumns = useMemo(
+    () => getRequiredProperties(stream?.json_schema),
+    [stream],
+  );
 
   useEffect(() => {
     if (data) {

--- a/src/views/Activate/Syncs/types.ts
+++ b/src/views/Activate/Syncs/types.ts
@@ -26,6 +26,7 @@ export type DiscoverResponse = {
 export type FieldMap = {
   model: string;
   destination: string;
+  isRequired?: boolean;
 };
 
 export type ConfigSync = {

--- a/src/views/Activate/Syncs/utils.ts
+++ b/src/views/Activate/Syncs/utils.ts
@@ -25,6 +25,28 @@ export const convertSchemaToObject = (schema: RJSFSchema): unknown => {
   }
 };
 
+export const getRequiredProperties = (schema?: RJSFSchema, parentKey = ''): string[] => {
+  const requiredProperties: string[] = [];
+
+  if (schema?.type === 'object' && schema.properties) {
+    Object.keys(schema.properties).forEach((property) => {
+      const propertySchema = schema?.properties?.[property] as RJSFSchema;
+      const propertyKey = parentKey ? `${parentKey}.${property}` : property;
+
+      if (schema.required && schema.required.includes(property)) {
+        requiredProperties.push(propertyKey);
+      }
+
+      if (propertySchema?.type === 'object') {
+        const subRequiredProperties = getRequiredProperties(propertySchema, propertyKey);
+        requiredProperties.push(...subRequiredProperties);
+      }
+    });
+  }
+
+  return requiredProperties;
+};
+
 export const getPathFromObject = (schema?: RJSFSchema) => {
   if (!schema) return [];
   const schemaObject = convertSchemaToObject(schema);


### PR DESCRIPTION
## Description
Added logic to pre-populate destination mapping fields which are marked as required.

<img width="965" alt="Screenshot 2024-03-12 at 12 08 38 AM" src="https://github.com/Multiwoven/multiwoven-ui/assets/29303618/b783aadf-12d1-4fcc-935d-0431829647b1">


## Related Issue
<!-- Link to any related issues or indicate 'None' if applicable e.g
 Relates to issue #123 - 'Enhance the process of fetching destinations details'. If none, state 'None'. -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would impact existing functionality)
- [ ] Styling change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore
  
## How Has This Been Tested?
<!-- Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:
- [x] Ensure a branch name is prefixed with `feature`, `bugfix`, `hotfix`, `release`, `style` or `chore` followed by `/` and branch name e.g `feature/add-salesforce-connector`
- [ ] Added unit tests for the changes made (if required)
- [x] Have you made sure the commit messages meets the guidelines?
- [x] Added relevant screenshots for the changes
- [x] Have you tested the changes on local/staging?
- [x] Have you made sure the code you have written follows the best practises to the best of your knowledge?
